### PR TITLE
Add missing dependency modules-ratings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Germany.
 * CMS Modules
   * default module, <https://github.com/koenige/modules-default>
   * clubs module, <https://github.com/schach-in/modules-clubs>
+  * ratings module, <https://github.com/schach-in/modules-ratings>
   * contacts module, <https://github.com/koenige/modules-contacts>
   * feedback module, <https://github.com/koenige/modules-feedback>
   * zzform module, <https://github.com/koenige/zzform>


### PR DESCRIPTION
I was not sure whether the `modules-ratings` is missing intentionally, and where it should be located. So just assigning this to @koenige :kissing_cat: 